### PR TITLE
Fixed-illegal-urlpassing-as-param

### DIFF
--- a/packages/common/src/controllers/file-upload.controller.ts
+++ b/packages/common/src/controllers/file-upload.controller.ts
@@ -54,6 +54,10 @@ export class FileUploadController {
     @Res() res: FastifyReply,
   ): Promise<void> {
     try {
+        const pathTraversalRegex = /\.\.\//;
+        if (pathTraversalRegex.test(destination)) {
+          throw new Error("Invalid Path entered")
+        }
       const fileStream = await this.filesService.download(destination);
       res.headers({
         'Content-Type': 'application/octet-stream',

--- a/packages/common/src/controllers/file-upload.controller.ts
+++ b/packages/common/src/controllers/file-upload.controller.ts
@@ -54,7 +54,7 @@ export class FileUploadController {
     @Res() res: FastifyReply,
   ): Promise<void> {
     try {
-        const pathTraversalRegex = /\.\.\//;
+        const pathTraversalRegex = /\.\.\/|\.\//g;
         if (pathTraversalRegex.test(destination)) {
           throw new Error("Invalid Path entered")
         }

--- a/packages/common/test/file-upload/file-upload.controller.spec.ts
+++ b/packages/common/test/file-upload/file-upload.controller.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FileUploadController } from '../../src/controllers/file-upload.controller';
+import { FileUploadService } from '../../src/services/file-upload.service'; // Ensure this path is correct
+import { FastifyReply } from 'fastify';
+
+describe('FileUploadController', () => {
+  let controller: FileUploadController;
+  let filesService: FileUploadService;
+
+  const mockRes = {
+    headers: jest.fn(),
+    raw: {
+      pipe: jest.fn(),
+    },
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+  } as unknown as FastifyReply;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FileUploadController],
+      providers: [
+        {
+          provide: FileUploadService,
+          useValue: {
+            download: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<FileUploadController>(FileUploadController);
+  });
+
+  it('should reject request with parameters containing ../', async () => {
+    const destination = ['..%2Ftest%2Fjest-e2e.json', '%2E%2E%2F.env'];
+    destination.map(async (file) => {
+      await controller.downloadFile(file, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.send).toHaveBeenCalledWith('File download failed');
+    });
+  });
+});

--- a/packages/common/test/file-upload/file-upload.controller.spec.ts
+++ b/packages/common/test/file-upload/file-upload.controller.spec.ts
@@ -5,7 +5,6 @@ import { FastifyReply } from 'fastify';
 
 describe('FileUploadController', () => {
   let controller: FileUploadController;
-  let filesService: FileUploadService;
 
   const mockRes = {
     headers: jest.fn(),
@@ -32,9 +31,10 @@ describe('FileUploadController', () => {
     controller = module.get<FileUploadController>(FileUploadController);
   });
 
-  it('should reject request with parameters containing ../', async () => {
-    const destination = ['..%2Ftest%2Fjest-e2e.json', '%2E%2E%2F.env'];
-    destination.map(async (file) => {
+  it('should reject request with parameters containing only filename.extension and filename is allowed  ../ ./ /', async () => {
+    // The following array coontains urlencoded rejectddestiantion [.././test/jest-e2e.json , ../.env , folder/index.js, folder/../../.env,
+    const RejectedDestination = ['..%2Ftest%2Fjest-e2e.json', '%2E%2E%2F.env' ,,'folder%2Findex.js','folder%2F..%2F..%2F.env' ];
+    RejectedDestination.map(async (file) => {
       await controller.downloadFile(file, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);


### PR DESCRIPTION
### Issue #120: Path Traversal Vulnerability via Illegal URL Destination Parameter

**Problem:**
Normally, when passing the destination parameter, a file is downloaded. However, if characters like `../` are added and passed as a parameter after URL encoding, it enables access to files outside of the directory. For instance, the string `../test/jest-e2e.json`, when URL encoded, can be passed as the destination parameter: `localhost:3000/files/download/..%2Ftest%2Fjest-e2e.json`. This results in the file being served as a response, potentially exposing sensitive information.

**How to Recreate:**
1. Pass a URL-encoded string containing `../` as the destination parameter.
2. Access the corresponding endpoint, for example: `localhost:3000/files/download/..%2Ftest%2Fjest-e2e.json`.
3. The content of the `jest-e2e.json` file is served as a response, revealing potentially sensitive data.

**Solution:**
To mitigate this vulnerability, we need to validate the destination parameter to ensure it does not contain any illegal characters or patterns that could lead to path traversal attacks. We can achieve this by implementing server-side validation and rejecting requests with invalid destination parameters.

**Changes:**
1. Implement validation checks for the destination parameter in the affected endpoint handler controller.
2. If the destination parameter contains illegal characters or patterns indicative of path traversal attempts, return an appropriate error response and do not serve the requested file.

### Test Cases

**Allowed Test Cases:**
The following folder structure and test cases are considered safe:
1. `new.txt`
   ![new.txt](https://github.com/SamagraX-Stencil/stencil/assets/147340395/f4748090-1211-4782-b2bd-fc801ae2ef99)
2. `demo.c`
   ![demo.c](https://github.com/SamagraX-Stencil/stencil/assets/147340395/9e9de9d3-c8f0-4124-a410-2314ad35fdc0)
3. `new1232.js`
   ![new1232.js](https://github.com/SamagraX-Stencil/stencil/assets/147340395/910f19fd-3546-4e41-968a-384e1cdbed48)

**Rejected Test Cases:**
Requests attempting to access `../.env` after URL encoding, which may leak information stored in the `.env` file, are rejected:
![Rejected Request](https://github.com/SamagraX-Stencil/stencil/assets/147340395/0eaaeac9-4b29-4daa-ae60-1a3d58a876db)
