### PR TITLE
fix: published types from package

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,13 +15,16 @@
   },
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "types"
   ],
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
+    "clean": "rimraf dist types",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
@@ -58,7 +61,9 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/cache-manager-redis-store": "^2.0.4",
     "@types/express": "^4.17.17",
+    "@types/fastify-multipart": "^0.7.0",
     "@types/jest": "^29.5.12",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.3.1",
@@ -80,7 +85,6 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.3"
   },
-  
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/packages/common/src/interfaces/fastify-multipart.d.ts
+++ b/packages/common/src/interfaces/fastify-multipart.d.ts
@@ -1,0 +1,17 @@
+declare module 'fastify-multipart' {
+    interface ParsedPart {
+      fieldname: string;
+      value: string;
+      fieldnameTruncated: boolean;
+      valueTruncated: boolean;
+      mimetype: string;
+      encoding: string;
+      filename: string;
+      limit: boolean;
+    }
+  
+    interface MultipartFields {
+      [key: string]: ParsedPart | ParsedPart[];
+    }
+  }
+  

--- a/packages/common/src/interfaces/file-upload.interface.ts
+++ b/packages/common/src/interfaces/file-upload.interface.ts
@@ -1,4 +1,4 @@
-import * as fastifyMutipart from 'fastify-multipart';
+import { MultipartFields } from 'fastify-multipart';
 
 export enum STORAGE_MODE {
   MINIO = 'minio',
@@ -13,5 +13,5 @@ export interface MultipartFile {
   filename: string;
   encoding: string;
   mimetype: string;
-  fields: fastifyMutipart.MultipartFields;
+  fields: MultipartFields;
 }

--- a/packages/common/src/services/file-upload.service.ts
+++ b/packages/common/src/services/file-upload.service.ts
@@ -23,11 +23,11 @@ export class FileUploadService {
     switch (process.env.STORAGE_MODE?.toLowerCase()) {
       case STORAGE_MODE.MINIO:
         this.storage = new Client({
-          endPoint: process.env.STORAGE_ENDPOINT,
-          port: parseInt(process.env.STORAGE_PORT),
+          endPoint: process.env.STORAGE_ENDPOINT as string,
+          port: parseInt(process.env.STORAGE_PORT as string),
           useSSL: this.useSSL,
-          accessKey: process.env.STORAGE_ACCESS_KEY,
-          secretKey: process.env.STORAGE_SECRET_KEY,
+          accessKey: process.env.STORAGE_ACCESS_KEY as string,
+          secretKey: process.env.STORAGE_SECRET_KEY as string,
         });
         break;
       default:
@@ -45,7 +45,7 @@ export class FileUploadService {
         filename,
         file.buffer,
         metaData,
-        function (err) {
+        function (err: Error | null) {
           if (err) {
             console.log('err: ', err);
             reject(err);

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "declaration": true,
+    "declarationDir": "./dist/types",
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -12,10 +13,17 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": false,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
-  }
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "strictBindCallApply": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test"
+  ]
 }


### PR DESCRIPTION
## Checklist
Make sure you have
- [ ] Added relevant `@nestjs/swagger` decorators wherever required 
- [ ] Added test cases (unit and integration) wherever required

## Description
* Added TypeScript `type declarations` for all packages within Stencil.
* Updated `tsconfig.json` to generate `.d.ts` files and included them in the build process.
* Modified `package.json` to reference the generated type definitions.

## Demo
https://drive.google.com/uc?id=1so9yliRJ_74WfFNqSrhaWhK3rWWta6CP&export=download

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced type safety with stricter type checking enabled in the project.

- **Chores**
  - Added a `"clean"` script to the package configuration.
  - Updated dependencies with type definitions for external packages.
  
- **Refactor**
  - Improved type declarations and imports for better maintainability and consistency.
  - Updated environment variable usage for more explicit type casting.
  
- **Documentation**
  - Adjusted `tsconfig.json` settings to improve code quality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->