### PR TITLE
Fix logo visibility issue in dark mode

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -35,7 +35,7 @@ module.exports = {
       logo: {
         alt: 'Site Logo',
         src: 'https://tech.samagragovernance.in/wp-content/uploads/2021/02/L2-e1614174909114.png',
-        srcDark: '/logos/dark-logo.png',
+        srcDark: 'https://tech.samagragovernance.in/wp-content/uploads/2021/02/L2-e1614174909114.png',
         href: '/',
         target: '_self',
         width: 140,


### PR DESCRIPTION
Fixes #189

Update the dark mode logo configuration in `docs/docusaurus.config.js`.

* Change the `srcDark` property to point to the light mode logo URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SamagraX-Stencil/stencil/issues/189?shareId=c7d58d35-a13e-47d3-b5e5-6e88e0a6021f).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the dark logo for the documentation site to ensure consistency by using an absolute URL.
  
- **Bug Fixes**
	- Resolved potential issues with logo display by changing the logo source from a relative path to an absolute URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->